### PR TITLE
Fix replace highlight

### DIFF
--- a/src/utils/cast.js
+++ b/src/utils/cast.js
@@ -115,7 +115,7 @@ export function formatCastText(text, searchQuery) {
 
   if (searchQuery) {
     const matches = new RegExp(searchQuery, 'gi')
-    text = text.replace(matches, (match) => `<b>${match}</b>`);
+    text = text.replace(matches, (match) => `<b>${match}</b>`)
 
     // remove <b> tags from hrefs
     const hrefs = text.match(/href="([^"]*)"/g)

--- a/src/utils/cast.js
+++ b/src/utils/cast.js
@@ -115,7 +115,7 @@ export function formatCastText(text, searchQuery) {
 
   if (searchQuery) {
     const matches = new RegExp(searchQuery, 'gi')
-    text = text.replace(matches, `<b>${searchQuery}</b>`)
+    text = text.replace(matches, (match) => `<b>${match}</b>`);
 
     // remove <b> tags from hrefs
     const hrefs = text.match(/href="([^"]*)"/g)


### PR DESCRIPTION
This PR fixes the bold text in the search results. We can use a function as a replacer in order to wrap the matches with the bold tags.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace

**Steps to reproduce**

1. Go to https://searchcaster.xyz/
2. Search "Bodies"

**Expected behaviour:**

The results should show the matches in the same case than the original cast. i.e. "BODIES BODIES BODIES"

**Actual behaviour:**

The results replace the highlighted text with the search query. "Bodies Bodies Bodies"

Before

<img width="593" alt="Screenshot 2022-08-15 at 23 29 11" src="https://user-images.githubusercontent.com/36676/184792091-f0d7f88f-9999-433c-9623-dd5deab0090f.png">

After

<img width="596" alt="Screenshot 2022-08-15 \at 23 18 41" src="https://user-images.githubusercontent.com/36676/184791931-f59c4d66-37f1-4d68-bde2-27ea3f8e069b.png">

