### PR TITLE
Create h-feed and RSS feed support for Searchcaster

### DIFF
--- a/public/search.xml
+++ b/public/search.xml
@@ -1,0 +1,11 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>Farcaster Search</ShortName>
+  <Description>Search casts in the Farcaster community</Description>
+  <InputEncoding>[UTF-8]</InputEncoding>
+  <Image width="16" height="16" type="image/x-icon">[https://searchcaster.xyz]</Image>
+  <Url type="text/html" template="https://searchcaster.xyz/search">
+    <Param name="text" value="{searchTerms}"/>
+  </Url>
+  <moz:SearchForm>https://searchcaster.xyz</moz:SearchForm>
+</OpenSearchDescription>

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -32,7 +32,7 @@ function App({ Component, pageProps }) {
         
         <link rel="search" type="application/opensearchdescription+xml" title="Farcaster Search" href="https://searchcaster.xyz/search.xml" />
 
-        {router.asPath ? <link rel="alternate" type="application/rss+xml" title="Farcaster Search" href={`https://granary.io/url?input=html&output=rss&url=https%3A%2F%2Fsearchcaster.xyz${router.asPath}`} /> : ""}
+        {router.asPath ? <link rel="alternate" type="application/rss+xml" title="Farcaster Search" href={`https://granary.io/url?input=html&output=rss&url=https%3A%2F%2Fsearchcaster.xyz${router.asPath}`} /> : ''}
 
         <meta
           property="og:image"

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -29,6 +29,10 @@ function App({ Component, pageProps }) {
         <link rel="icon" href="/img/favicon-32.png" sizes="32x32" />
         <link rel="icon" href="/img/favicon-64.png" sizes="64x64" />
         <link rel="icon" href="/img/favicon-96.png" sizes="96x96" />
+        
+        <link rel="search" type="application/opensearchdescription+xml" title="Farcaster Search" href="https://searchcaster.xyz/search.xml" />
+
+        {router.asPath ? <link rel="alternate" type="application/rss+xml" title="Farcaster Search" href={`https://granary.io/url?input=html&output=rss&url=https%3A%2F%2Fsearchcaster.xyz${router.asPath}`} /> : ""}
 
         <meta
           property="og:image"

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -126,24 +126,24 @@ function Casts({ casts, query }) {
     query.page && url.replace(/page=\d+/, `page=${page - 1}`)
 
   return casts.length > 0 ? (
-    <div className="casts">
+    <div className="casts h-feed">
       {casts.map((cast, i) => (
         <div key={cast.merkleRoot}>
-          <div className="cast">
+          <div className="cast h-entry">
             <div className="cast__body">
-              <div className="cast__author">
+              <div className="cast__author h-card">
                 {cast.meta.avatar && (
                   // eslint-disable-next-line @next/next/no-img-element
                   <img
                     src={cast.meta.avatar}
-                    className="cast__avatar"
+                    className="cast__avatar u-photo"
                     alt=""
                     width={44}
                     height={44}
                   />
                 )}
                 <div className="cast__names">
-                  <span className="cast__display-name">
+                  <span className="cast__display-name p-name p-nickname">
                     {cast.meta.displayName}
                   </span>
                   <Link href={`/search?username=${cast.body.username}`}>
@@ -152,18 +152,18 @@ function Casts({ casts, query }) {
                 </div>
               </div>
 
-              <span className="cast__date">
+              <span className="cast__date dt-published">
                 {getRelativeDate(cast.body.publishedAt)}
               </span>
 
-              <p className="cast__text">
+              <p className="cast__text e-content">
                 {formatCastText(cast.body.data.text, query.text)}
               </p>
 
               {cast.body.data.image && (
                 <a
                   href={cast.body.data.image}
-                  className="cast__attachment-link"
+                  className="cast__attachment-link u-photo u-featured"
                   target="_blank"
                   rel="noreferrer"
                 >


### PR DESCRIPTION
This PR introduces three changes:

1. Add [h-feed](https://microformats.org/wiki/h-feed) markup to Searchcaster results pages.
2. Add a meta tag to granary.io, a service that translates h-feeds into other types of feeds. The meta tag turns search result h-feeds into RSS feeds.
3. Add an OpenSearch description so you can save Searchcaster as a search option in your browser.